### PR TITLE
Update fabric and fix ghost updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'maven-publish'
-	id 'fabric-loom' version '1.5-SNAPSHOT'
-	id 'ploceus' version '1.5-SNAPSHOT'
+	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'ploceus' version '1.8-SNAPSHOT'
 }
 
 base {
@@ -25,7 +25,6 @@ dependencies {
 
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	ploceus.addCommonLibraries()
 	ploceus.dependOsl(project.osl_version)
 	include(implementation("net.dv8tion:JDA:${project.jda_version}"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,7 @@ archives_base_name = bismuthserver
 
 # Dependencies
 minecraft_version = 1.12.2
-feather_build = 25
-loader_version = 0.15.6
-
-osl_version = 0.12.1
+loader_version = 0.16.10
+osl_version = 0.16.3
+feather_build = 28
 jda_version = 5.0.0-beta.20

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
@@ -1,0 +1,25 @@
+package si.bismuth.mixins;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.DispenserBlock;
+import net.minecraft.block.state.BlockState;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.server.entity.living.player.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DispenserBlock.class)
+public class DispenserBlockMixin {
+    @Inject(method = "neighborChanged", at = @At("TAIL"))
+    public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
+        if (world.getServer().getPlayerManager().getAll() != null) {
+            for (ServerPlayerEntity player : world.getServer().getPlayerManager().getAll()) {
+                player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
+            }
+        }
+    }
+}

--- a/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
@@ -18,11 +18,6 @@ import java.util.List;
 public class DispenserBlockMixin {
     @Inject(method = "neighborChanged", at = @At("TAIL"))
     public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
-        List<ServerPlayerEntity> players = world.getServer().getPlayerManager().getAll();
-        if (players != null) {
-            for (ServerPlayerEntity player : players) {
-                player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
-            }
-        }
+        world.notifyBlockChanged(pos, state, state, 0);
     }
 }

--- a/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
@@ -12,12 +12,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.List;
+
 @Mixin(DispenserBlock.class)
 public class DispenserBlockMixin {
     @Inject(method = "neighborChanged", at = @At("TAIL"))
     public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
-        if (world.getServer().getPlayerManager().getAll() != null) {
-            for (ServerPlayerEntity player : world.getServer().getPlayerManager().getAll()) {
+        List<ServerPlayerEntity> players = world.getServer().getPlayerManager().getAll();
+        if (players != null) {
+            for (ServerPlayerEntity player : players) {
                 player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
             }
         }

--- a/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/DispenserBlockMixin.java
@@ -3,16 +3,12 @@ package si.bismuth.mixins;
 import net.minecraft.block.Block;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.state.BlockState;
-import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
-import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.List;
 
 @Mixin(DispenserBlock.class)
 public class DispenserBlockMixin {

--- a/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
@@ -3,15 +3,12 @@ package si.bismuth.mixins;
 import net.minecraft.block.Block;
 import net.minecraft.block.HopperBlock;
 import net.minecraft.block.state.BlockState;
-import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
-import net.minecraft.server.entity.living.player.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import java.util.List;
 
 @Mixin(HopperBlock.class)
 public class HopperBlockMixin {

--- a/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
@@ -11,13 +11,15 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import java.util.List;
 
 @Mixin(HopperBlock.class)
 public class HopperBlockMixin {
     @Inject(method = "neighborChanged", at = @At("TAIL"))
     public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
-        if (world.getServer().getPlayerManager().getAll() != null) {
-            for (ServerPlayerEntity player : world.getServer().getPlayerManager().getAll()) {
+        List<ServerPlayerEntity> players = world.getServer().getPlayerManager().getAll();
+        if (players != null) {
+            for (ServerPlayerEntity player : players) {
                 player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
             }
         }

--- a/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
@@ -17,11 +17,6 @@ import java.util.List;
 public class HopperBlockMixin {
     @Inject(method = "neighborChanged", at = @At("TAIL"))
     public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
-        List<ServerPlayerEntity> players = world.getServer().getPlayerManager().getAll();
-        if (players != null) {
-            for (ServerPlayerEntity player : players) {
-                player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
-            }
-        }
+        world.notifyBlockChanged(pos, state, state, 0);
     }
 }

--- a/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
+++ b/src/main/java/si/bismuth/mixins/HopperBlockMixin.java
@@ -1,0 +1,25 @@
+package si.bismuth.mixins;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.HopperBlock;
+import net.minecraft.block.state.BlockState;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.server.entity.living.player.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(HopperBlock.class)
+public class HopperBlockMixin {
+    @Inject(method = "neighborChanged", at = @At("TAIL"))
+    public void neighborChanged(BlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos, CallbackInfo ci) {
+        if (world.getServer().getPlayerManager().getAll() != null) {
+            for (ServerPlayerEntity player : world.getServer().getPlayerManager().getAll()) {
+                player.networkHandler.sendPacket(new BlockUpdateS2CPacket(world, pos));
+            }
+        }
+    }
+}

--- a/src/main/java/si/bismuth/mixins/MovingBlockEntityMixin.java
+++ b/src/main/java/si/bismuth/mixins/MovingBlockEntityMixin.java
@@ -42,7 +42,7 @@ public class MovingBlockEntityMixin extends BlockEntity {
 	@Inject(method = "tick", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/BlockState;I)Z"))
 	private void tick(CallbackInfo ci) {
 		final BlockState state = this.world.getBlockState(this.pos);
-		this.world.onBlockChanged(pos.offset(state.get(PistonHeadBlock.FACING).getOpposite()), state, state, 0);
+		this.world.onBlockChanged(pos.offset(state.get(PistonHeadBlock.FACING).getOpposite()), state.getBlock(), false);
 	}
 
 	@Inject(method = "moveEntities", at = @At(value = "INVOKE", target = "Ljava/lang/ThreadLocal;set(Ljava/lang/Object;)V", ordinal = 1, shift = At.Shift.AFTER, remap = false), locals = LocalCapture.CAPTURE_FAILHARD)

--- a/src/main/java/si/bismuth/utils/BlockRotator.java
+++ b/src/main/java/si/bismuth/utils/BlockRotator.java
@@ -91,7 +91,7 @@ public class BlockRotator {
 		} else {
 			return false;
 		}
-		worldIn.onRegionChanged(pos, pos);
+		worldIn.notifyRegionChanged(pos, pos);
 		return true;
 	}
 

--- a/src/main/resources/mixins.bismuthserver.json
+++ b/src/main/resources/mixins.bismuthserver.json
@@ -42,7 +42,9 @@
 		"TraderMenuMixin",
 		"WorldChunkMixin",
 		"WorldMixin",
-		"XpOrbEntityMixin"
+		"XpOrbEntityMixin",
+		"DispenserBlockMixin",
+		"HopperBlockMixin"
 	],
 	"client": [
 		"IInventoryMenuScreenMixin",


### PR DESCRIPTION
Fixes dispenser, dropper and hopper block state changes only being done on server world. Occasionally causing confusion and brain damage. 

Assuming other Bis members are okay with it of course. 